### PR TITLE
tell docker to relabel the temp volume for selinux-enabled systems (fedora)

### DIFF
--- a/cmd/gokr-rebuild-kernel/kernel.go
+++ b/cmd/gokr-rebuild-kernel/kernel.go
@@ -192,7 +192,7 @@ func main() {
 	dockerRun := exec.Command("docker",
 		"run",
 		"--rm",
-		"--volume", tmp+":/tmp/buildresult",
+		"--volume", tmp+":/tmp/buildresult:Z",
 		"gokr-rebuild-kernel")
 	dockerRun.Dir = tmp
 	dockerRun.Stdout = os.Stdout


### PR DESCRIPTION
Relabelling the temporary exchange volume helps the container actually
write its output file in an selinux enabled distro.

Otherwise the build will fail right at the end, with this kind of error:

2019/02/02 13:07:18 open /tmp/buildresult/vmlinuz: permission denied
2019/02/02 14:07:48 docker run: exit status 1 (cmd: [docker run --rm --volume /tmp/gokr-rebuild-kernel492463864:/tmp/buildresult gokr-rebuild-kernel])

And an SELINUX alert:
type=AVC msg=audit(1549112838.725:536): avc:  denied  { write } for  pid=15380 comm="gokr-build-kern" name="gokr-rebuild-kernel492463864" dev="tmpfs" ino=230676 scontext=system_u:system_r:container_t:s0:c485,c1017 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=dir permissive=0