### PR TITLE
cmd/gokr-build-kernel: enable USB printer support

### DIFF
--- a/cmd/gokr-build-kernel/build.go
+++ b/cmd/gokr-build-kernel/build.go
@@ -41,6 +41,9 @@ CONFIG_USB_SERIAL_CP210X=y
 # For physically connecting the scan2drive USB LCD:
 CONFIG_USB_ACM=y
 
+# Enable USB printer support /dev/usb/lp0.
+CONFIG_USB_PRINTER=y
+
 # enable simple framebuffer for early boot
 CONFIG_FB_SIMPLE=y
 


### PR DESCRIPTION
Enabling USB LP support in the kernel appears to increase the vmlinux size by 2KB.
In return many USB printers get mounted as `/dev/usb/lpN`.

I'm using gokrazy as a label print server. Many label printers, such as:
 * Zebra
 * DuraLabel
 * Dymo

Will all appear as usb devices with this enable where commands can be directly written to them in
the instruction set they support. Zebra supports ZPL2, DuraLabel supports a BASIC style language, and Dymo supports a run length encoded image. As such, no high level printer system is needed to utilize
this functionality.
