### PR TITLE
fix gokrazy-rebuild-kernel when podman-docker is installed

### DIFF
--- a/cmd/gokr-rebuild-kernel/kernel.go
+++ b/cmd/gokr-rebuild-kernel/kernel.go
@@ -100,7 +100,9 @@ func find(filename string) (string, error) {
 }
 
 func getContainerExecutable() (string, error) {
-	choices := []string{"docker", "podman"}
+	// Probe podman first, because the docker binary might actually
+	// be a thin podman wrapper with podman behavior.
+	choices := []string{"podman", "docker"}
 	for _, exe := range choices {
 		p, err := exec.LookPath(exe)
 		if err != nil {


### PR DESCRIPTION
podman provides a podman-based docker command for compatibility.

Previously, if this was present, gokrazy-rebuild-kernel would detect
"docker", and elide --userns=keep-id, leading to the owner of
/tmp/buildresult (as seen inside the container) staying root, and since
the directory is 700 copying vmlinuz to the directory would fail:

    2020/05/09 02:57:13 open /tmp/buildresult/vmlinuz: permission denied
    2020/05/08 19:57:16 docker run: exit status 1 (cmd: [/usr/bin/docker run --rm --volume /tmp/gokr-rebuild-kernel653178216:/tmp/buildresult:Z gokr-rebuild-kernel])

This commit fixes the issue by probing for podman before docker.

(Note the reverse, a docker-based podman command, currently does not exist.)

Fixes #258