### PR TITLE
cmd/gokr-build-kernel: configure Raspberry Pi 4 hwmon support

### DIFF
--- a/cmd/gokr-build-kernel/build.go
+++ b/cmd/gokr-build-kernel/build.go
@@ -174,6 +174,11 @@ CONFIG_MACVLAN=y
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y
 
+# For Raspberry Pi 4 hwmon:
+CONFIG_HWMON=y
+CONFIG_BCM2711_THERMAL=y
+CONFIG_SENSORS_RASPBERRYPI_HWMON=y
+
 # TODO: trim the settings below to the minimum set that works (taken from debian)
 ##
 ## file: arch/arm64/Kconfig

--- a/cmd/gokr-build-kernel/build.go
+++ b/cmd/gokr-build-kernel/build.go
@@ -179,6 +179,10 @@ CONFIG_HWMON=y
 CONFIG_BCM2711_THERMAL=y
 CONFIG_SENSORS_RASPBERRYPI_HWMON=y
 
+# For Raspberry Pi 4 CPU frequency:
+CONFIG_CLK_RASPBERRYPI=y
+CONFIG_ARM_RASPBERRYPI_CPUFREQ=y
+
 # TODO: trim the settings below to the minimum set that works (taken from debian)
 ##
 ## file: arch/arm64/Kconfig


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Enables the temperature and voltage critical sensors. I figured these out with a bit of googling around, but let me know if this isn't quite right. Thanks!

```
# HELP node_hwmon_chip_names Annotation metric for human-readable chip names
# TYPE node_hwmon_chip_names gauge
node_hwmon_chip_names{chip="soc:firmware_raspberrypi_hwmon",chip_name="rpi_volt"} 1
node_hwmon_chip_names{chip="thermal_thermal_zone0",chip_name="cpu_thermal"} 1
# HELP node_hwmon_in_lcrit_alarm_volts Hardware monitor for voltage (lcrit_alarm)
# TYPE node_hwmon_in_lcrit_alarm_volts gauge
node_hwmon_in_lcrit_alarm_volts{chip="soc:firmware_raspberrypi_hwmon",sensor="in0"} 0
# HELP node_hwmon_temp_celsius Hardware monitor for temperature (input)
# TYPE node_hwmon_temp_celsius gauge
node_hwmon_temp_celsius{chip="thermal_thermal_zone0",sensor="temp0"} 62.322
node_hwmon_temp_celsius{chip="thermal_thermal_zone0",sensor="temp1"} 62.322
# HELP node_hwmon_temp_crit_celsius Hardware monitor for temperature (crit)
# TYPE node_hwmon_temp_crit_celsius gauge
node_hwmon_temp_crit_celsius{chip="thermal_thermal_zone0",sensor="temp1"} 90
```