### PR TITLE
Allow kernel builds on arm64 hosts

### DIFF
--- a/cmd/gokr-rebuild-kernel/kernel.go
+++ b/cmd/gokr-rebuild-kernel/kernel.go
@@ -15,7 +15,7 @@ import (
 )
 
 const dockerFileContents = `
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && apt-get install -y crossbuild-essential-arm64 bc libssl-dev bison flex kmod
 


### PR DESCRIPTION
Upgrading the container image to `buster` avoids this dependency problem with `crossbuild-essential-arm64`.

```ShellSession
$ gokr-rebuild-kernel
2022/12/09 12:42:53 building podman container for kernel compilation
STEP 1/11: FROM debian:stretch
Resolved "debian" as an alias (/etc/containers/registries.conf.d/000-shortnames.conf)
Trying to pull docker.io/library/debian:stretch...
Getting image source signatures
Copying blob d8ccec8a513f done
Copying config 6e15796b45 done
Writing manifest to image destination
Storing signatures
STEP 2/11: RUN apt-get update && apt-get install -y crossbuild-essential-arm64 bc libssl-dev bison flex kmod
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [59.1 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://security.debian.org/debian-security stretch/updates/main arm64 Packages [762 kB]
Get:6 http://deb.debian.org/debian stretch Release.gpg [3177 B]
Get:7 http://deb.debian.org/debian stretch/main arm64 Packages [6921 kB]
Fetched 7956 kB in 1s (4384 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 crossbuild-essential-arm64 : Depends: gcc-aarch64-linux-gnu (>= 5.3) but it is not installable
                              Depends: g++-aarch64-linux-gnu (>= 5.3) but it is not installable
E: Unable to correct problems, you have held broken packages.
Error: building at STEP "RUN apt-get update && apt-get install -y crossbuild-essential-arm64 bc libssl-dev bison flex kmod": while running runtime: exit status 100
2022/12/09 12:43:05 podman build: exit status 100 (cmd: [podman build --rm=true --tag=gokr-rebuild-kernel .])```