### PR TITLE
Enable policy routing (fix #555)

### DIFF
--- a/cmd/gokr-build-kernel/build.go
+++ b/cmd/gokr-build-kernel/build.go
@@ -216,6 +216,10 @@ CONFIG_NETFILTER_XT_MATCH_COMMENT=y
 CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
 CONFIG_NETFILTER_XT_MARK=y
 
+# Enable policy routing (required for Tailscale)
+CONFIG_IP_MULTIPLE_TABLES=y
+CONFIG_IPV6_MULTIPLE_TABLES=y
+
 # TODO: trim the settings below to the minimum set that works (taken from debian)
 ##
 ## file: arch/arm64/Kconfig


### PR DESCRIPTION
Tailscale requires IPv6 policy routing in order to enable IPv6 support on the tailscale0 interface. This change adds the necessary kernel config options to enable policy routing for both IPv4 and IPv6.

I've tested this change on both a Raspberry Pi 3 and a (temporarily borrowed) Raspberry Pi 4 and it fixes the issue with Tailscale. I can connect to the web interface and use breakglass over IPv6 on my tailnet.