### PR TITLE
Adds exfat compatability

### DIFF
--- a/cmd/gokr-build-kernel/config.addendum.txt
+++ b/cmd/gokr-build-kernel/config.addendum.txt
@@ -99,6 +99,9 @@ CONFIG_LIBCRC32C=y
 # For FUSE (for cpu(1)):
 CONFIG_FUSE_FS=y
 
+# For exfat compat
+CONFIG_EXFAT_FS=y
+
 # For periph.io:
 CONFIG_GPIO_SYSFS=y
 CONFIG_SPI_SPIDEV=y


### PR DESCRIPTION
As [discussed](https://github.com/gokrazy/gokrazy/discussions/235) in the Gokrazy main repo, this just adds the `CONFIG_EXFAT_FS=y` flag to the `cmd/gokr-build-kernel/config.addendum.txt` file, enabling the use of exfat file systems.

As far as I could tell this doesn't significantly increase the kernel size, but please let me know if that's not accurate.