### PR TITLE
Add bcachefs to config.addendum.txt

### DIFF
--- a/cmd/gokr-build-kernel/config.addendum.txt
+++ b/cmd/gokr-build-kernel/config.addendum.txt
@@ -102,6 +102,9 @@ CONFIG_FUSE_FS=y
 # For exfat compat
 CONFIG_EXFAT_FS=y
 
+# For bcachefs
+CONFIG_BCACHEFS_FS=y
+
 # For periph.io:
 CONFIG_GPIO_SYSFS=y
 CONFIG_SPI_SPIDEV=y


### PR DESCRIPTION
If there is interest in supporting bcachefs: I got bcachefs working with gokrazy on an rpi4. Might be fun for NAS builds eventually. 

I built bcachefs-tools on the pi and ran `bcachefs format /dev/sdX`. Then modified gokrazy/mount.go to accept `bcache` fs type for mounting `/perm`.

I'd add support to `gokrazy/mkfs` if there is any desire to have that support creating bcachefs as well.
